### PR TITLE
code-server: fjernet pandoc-citeproc

### DIFF
--- a/dockerfiles/Dockerfile.code-server
+++ b/dockerfiles/Dockerfile.code-server
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tzdata \
     sudo \
     pandoc \
-    pandoc-citeproc \
     libcurl3-gnutls \
     libcurl4-gnutls-dev \
     libcairo2-dev \


### PR DESCRIPTION
Er nå en del av pandoc. Bygging feiler, siden pakken ikke finnes lenger